### PR TITLE
Cart count position fix

### DIFF
--- a/assets/theme-supplement.css
+++ b/assets/theme-supplement.css
@@ -393,8 +393,17 @@ h2 {
 
 .SC-Count {
   position: absolute;
-  top: 0;
-  right: -15px;
+}
+@media screen and (min-width: 768px) {
+  .SC-Count {
+    top: -3px;
+    right: -10px;
+  }
+}
+@media screen and (min-width: 1268px) {
+  .SC-Count {
+    position: initial;
+  }
 }
 
 .sc-container:not(.sc-container-capsule),
@@ -538,6 +547,10 @@ h2 {
   display: inline-flex;
 }
 
+.sc-align-items-end {
+  align-items: end;
+}
+
 @media screen and (min-width: 768px) {
   .sc-md\:justify-self-center {
     justify-self: center;
@@ -631,4 +644,4 @@ h2 {
   transform: rotate(270deg);
 }
 
-/*# sourceMappingURL=styles.css.map */
+/*# sourceMappingURL=theme-supplement.css.map */

--- a/templates/snippets/header/dropdown/cart.liquid
+++ b/templates/snippets/header/dropdown/cart.liquid
@@ -7,7 +7,7 @@
 {%- endcapture %}
 
 <li class="SC-Menu_item dropdown" data-root-nav data-cart-menu>
-  <a href="{{ current_store.cart_path }}" class="SC-Menu_link sc-hide-up-to-medium" data-nav-trigger="cart">
+  <a href="{{ current_store.cart_path }}" class="SC-Menu_link sc-hide-up-to-medium sc-align-items-end" data-nav-trigger="cart">
     <span class="sc-hide-up-to-xlarge u-pointer-events-none">
       {{ "header.dropdowns.cart.heading" | t }}
     </span>


### PR DESCRIPTION
# Motivation

The cart count overlaps the string 'cart' on larger devices 1268px and on. To fix it correctly, I have done some small tweaks on smaller devices, tablets and larger devices.

## Additions

I have also added `sc-align-items-end` as a global utility class as it doesn't exist as a default CSS at the moment.

### Screenshots

<img width="1462" alt="cart_count_fix" src="https://github.com/GetStoreConnect/corporate-theme/assets/77841884/564a17f3-d696-4e4a-bf85-6737b32604ea">

