### PR TITLE
Search bar transition fix

### DIFF
--- a/assets/theme-supplement.css
+++ b/assets/theme-supplement.css
@@ -124,6 +124,18 @@ h2 {
 .sc-header_search {
   position: relative;
   transition: all 2s ease;
+  visibility: hidden;
+  max-height: 0;
+  opacity: 0;
+  transition: opacity 0.3s ease, max-height 0.3s ease, padding 0.3s ease;
+  padding: 0;
+}
+.sc-header_search.is-active {
+  visibility: visible;
+  max-height: 85px;
+  opacity: 1;
+  padding-top: var(--sc-spacing-medium);
+  transition: all 0.5s;
 }
 .sc-header_inner {
   transition: 0.35s;

--- a/assets/theme-supplement.css
+++ b/assets/theme-supplement.css
@@ -121,7 +121,7 @@ h2 {
 .sc-header_top_inner {
   position: relative;
 }
-.sc-header_search {
+.sc-header_search.is-hidden {
   position: relative;
   transition: all 2s ease;
   visibility: hidden;
@@ -130,7 +130,7 @@ h2 {
   transition: opacity 0.3s ease, max-height 0.3s ease, padding 0.3s ease;
   padding: 0;
 }
-.sc-header_search.is-active {
+.sc-header_search:not(.is-hidden) {
   visibility: visible;
   max-height: 85px;
   opacity: 1;

--- a/assets/theme-supplement.css
+++ b/assets/theme-supplement.css
@@ -129,6 +129,8 @@ h2 {
   opacity: 0;
   transition: opacity 0.3s ease, max-height 0.3s ease, padding 0.3s ease;
   padding: 0;
+  display: block;
+  height: 0;
 }
 .sc-header_search:not(.is-hidden) {
   visibility: visible;
@@ -136,6 +138,7 @@ h2 {
   opacity: 1;
   padding-top: var(--sc-spacing-medium);
   transition: all 0.5s;
+  height: auto;
 }
 .sc-header_inner {
   transition: 0.35s;


### PR DESCRIPTION
## Motivation

The current search bar transition on active state is quite straight-forward and doesn't provide a smooth transition.

### Notes

There were changes on `toggle.js`, we now use the  `.is-hidden` class to handle display block and none. This change enforce us to play with this class and its properties. The current solution proposes a reset by setting display block as an initial state but setting the height to 0.

There's not transition properties for display block and none requiring to find other solutions to smooth out the transition.

**Link for testing:**

https://00dqe000003547h2aa.m-s-9ae1ab7f.storeconnect.app/?theme-preview=a34QE00000PSyiqYAD