### PR TITLE
Hot fix: syntax error that prevent products from showing

### DIFF
--- a/templates/blocks/featured_products.liquid
+++ b/templates/blocks/featured_products.liquid
@@ -25,7 +25,7 @@
   </div>
   {% endif %}
 
-  {%- assign count = content_block.products | size %-}
+  {%- assign count = content_block.products | size -%}
 
   {% if count <= 3 %}
     <div class="sc-grid sc-two-to-three-column">


### PR DESCRIPTION
## Motivation

The counter variable contain a synxtax error.