### PR TITLE
Theme Cleanup

### DIFF
--- a/assets/theme-supplement.css
+++ b/assets/theme-supplement.css
@@ -1,22 +1,3 @@
-:root {
-  --sc-header-bg: white;
-  --sc-header-color: var(--sc-shade-darkest);
-  --sc-menu-link-color-hover: var(--sc-shade-dark);
-  --sc-footer-bg: #FCFCFC;
-  --sc-footer-color: hsl(222, 71%, 12%);
-  --sc-font-family: "Inter", apple-system, BlinkMacSystemFont, sans-serif;
-  --sc-font-family-secondary: "Rubik", apple-system, BlinkMacSystemFont, sans-serif;
-  --sc-border-radius: 5px;
-  --sc-border-rounded: 10px;
-  --sc-border-width: 2px;
-  --sc-border-width-md: 720px;
-  --sc-max-width-lg: calc(1190px + 60px);
-  --sc-max-width: calc(1190px + 60px);
-  --sc-max-width-skinny: 760px;
-  --sc-line-height: 1.5;
-  --sc-grid-gap: 25px;
-}
-
 body {
   font-size: var(--sc-font-medium);
 }

--- a/templates/layouts/theme.liquid
+++ b/templates/layouts/theme.liquid
@@ -26,6 +26,7 @@
     {{ theme_supplement_stylesheet }}
     {% if current_store.global_css != blank %}<style>{{ current_store.global_css }}</style>{% endif %}
     {%- render "styles" %}
+    {%- render "shared/root_css" %}
 
     {%- comment -%} Scripts {%- endcomment -%}
     {%- require "scripts/configure.js" %}

--- a/templates/snippets/icons/chevron.liquid
+++ b/templates/snippets/icons/chevron.liquid
@@ -1,7 +1,0 @@
-{%- default style_class: blank -%}
-{%- default rotate: blank -%}
-{%- default width: 14 -%}
-
-<svg {% if style_class %}class="{{ style_class }}{% endif style_class %}" width="{{ width }}" viewBox="0 0 512 512">
-  <path d="M256 429.3l22.6-22.6 192-192L493.3 192 448 146.7l-22.6 22.6L256 338.7 86.6 169.4 64 146.7 18.7 192l22.6 22.6 192 192L256 429.3z"/>
-</svg>

--- a/templates/snippets/shared/root_css.liquid
+++ b/templates/snippets/shared/root_css.liquid
@@ -1,0 +1,18 @@
+:root {
+  --sc-header-bg: white;
+  --sc-header-color: var(--sc-shade-darkest);
+  --sc-menu-link-color-hover: var(--sc-shade-dark);
+  --sc-footer-bg: #FCFCFC;
+  --sc-footer-color: hsl(222, 71%, 12%);
+  --sc-font-family: "Inter", apple-system, BlinkMacSystemFont, sans-serif;
+  --sc-font-family-secondary: "Rubik", apple-system, BlinkMacSystemFont, sans-serif;
+  --sc-border-radius: 5px;
+  --sc-border-rounded: 10px;
+  --sc-border-width: 2px;
+  --sc-border-width-md: 720px;
+  --sc-max-width-lg: calc(1190px + 60px);
+  --sc-max-width: calc(1190px + 60px);
+  --sc-max-width-skinny: 760px;
+  --sc-line-height: 1.5;
+  --sc-grid-gap: 25px;
+}


### PR DESCRIPTION
- Moved the root CSS from the theme supplement CSS into a new template: root_css.
- Deleted snippets/icons/chevron since it isn’t used in the theme and we already have snippets/shared/icons/chevron.